### PR TITLE
Correct result when when the unknow is to the right of a non-reversible operator

### DIFF
--- a/src/simplify/expression/expr_types.c
+++ b/src/simplify/expression/expr_types.c
@@ -50,8 +50,8 @@ void expression_init_function(expression_t* expr, char* name, size_t len, expres
 void expression_clean(expression_t* expr) {
     switch (expr->type) {
         case EXPRESSION_TYPE_PREFIX:
-            expression_clean(expr->operator.right);
-            free(expr->operator.right);
+            expression_clean(expr->prefix.right);
+            free(expr->prefix.right);
             break;
         case EXPRESSION_TYPE_OPERATOR:
             expression_clean(expr->operator.left);

--- a/src/simplify/expression/expression.c
+++ b/src/simplify/expression/expression.c
@@ -57,7 +57,7 @@ int _expression_has_variable_or_function_recursive(expression_t* expr, variable_
         }
         case EXPRESSION_TYPE_PREFIX:
         {
-            if (_expression_has_variable_or_function_recursive(expr->operator.right, var))
+            if (_expression_has_variable_or_function_recursive(expr->prefix.right, var))
                 return 1;
             return 0;
         }

--- a/src/simplify/expression/expression.h
+++ b/src/simplify/expression/expression.h
@@ -28,4 +28,14 @@ variable_t expression_find_variable(expression_t* expr);
  */ 
 variable_t expression_find_function(expression_t* expr);
 
+/* swap an operator expression's left and right branch
+ * 
+ * @expr _expr->type must be EXPRESSION_TYPE_OPERATOR_ expression to swap
+ */
+static inline void expression_swap(expression_t* expr) {
+    expression_t* lx = EXPRESSION_LEFT(expr);
+    expr->operator.left = EXPRESSION_RIGHT(expr);
+    expr->operator.right = lx;
+}
+
 #endif  // SIMPLIFY_EXPRESSION_EXPRESSION_H_


### PR DESCRIPTION
Change behavior if the unknown is to the right of the `-`, `/` or `\` operator.